### PR TITLE
Add support for custom classes localizing (`R18n.l`)

### DIFF
--- a/r18n-core/lib/r18n-core/locale.rb
+++ b/r18n-core/lib/r18n-core/locale.rb
@@ -181,7 +181,12 @@ module R18n
 
         send format_method_name, obj, *params
       else
-        obj.to_s
+        format_method_name =
+          "format_#{Utils.underscore(obj.class.name)}_#{format}"
+
+        return obj.to_s unless respond_to? format_method_name
+
+        send format_method_name, obj, *params
       end
     end
 

--- a/r18n-core/lib/r18n-core/utils.rb
+++ b/r18n-core/lib/r18n-core/utils.rb
@@ -55,5 +55,14 @@ module R18n
       end
       one
     end
+
+    def self.underscore(string)
+      string
+        .gsub(/::/, '/')
+        .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+        .gsub(/([a-z\d])([A-Z])/, '\1_\2')
+        .tr('-', '_')
+        .downcase
+    end
   end
 end

--- a/r18n-core/spec/locale_spec.rb
+++ b/r18n-core/spec/locale_spec.rb
@@ -203,6 +203,24 @@ describe R18n::Locale do
     expect(@en.localize(Date.today - 1, :my_own_way)).to eq('Just another day')
   end
 
+  it 'localizes custom classes if formatter exists' do
+    stub_const(
+      'FooBar', Class.new do
+        attr_reader :value
+
+        def initialize(value)
+          @value = value
+        end
+      end
+    )
+
+    foo_bar = FooBar.new 'something'
+
+    allow(@en).to receive(:format_foo_bar_human, &:value)
+
+    expect(@en.localize(foo_bar, :human)).to eq('something')
+  end
+
   it 'raises error on unknown formatter' do
     expect do
       @ru.localize(Time.at(0).utc, R18n::I18n.new('ru'), :unknown)


### PR DESCRIPTION
You can just define `R18n::Locale#format_{underscored_class_name}_{format}` method
for this in your projects, like `#format_foo_bar_human`.

---

@ai, what do you think? It requires an additional (the first for `r18n-core`) dependency, because Ruby (stdlib) still has no `String#underscore` method.

It can be `ActiveSupport`, but I like mine gem with refinements (namespace patching instead of global).

There is can be another alternative, or requirement for methods with names like `#format_FooBar_human`.