### PR TITLE
Fix compatibility with Capybara >=3.0.0 matchers

### DIFF
--- a/r18n-core/lib/r18n-core/translated_string.rb
+++ b/r18n-core/lib/r18n-core/translated_string.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: true
 
 # Translation string for i18n support.
@@ -84,6 +85,10 @@ module R18n
 
     # Return untranslated, when user try to go deeper in translation.
     def method_missing(name, *_params)
+      # Maintain API compatibility with String#to_hash
+      # Necessary because otherwise it breaks when passed to
+      # methods with signature m(*a, **b)
+      return super if name == :to_hash
       get_untranslated(name.to_s)
     end
   end

--- a/r18n-core/spec/translation_spec.rb
+++ b/r18n-core/spec/translation_spec.rb
@@ -70,6 +70,11 @@ describe R18n::Translation do
     expect(str.to_s).to eq('a & b')
   end
 
+  it 'does not respond to to_hash' do
+    i18n = R18n::I18n.new('en', DIR)
+    expect(i18n.one).to_not respond_to(:to_hash)
+  end
+
   it 'loads use hierarchical translations' do
     i18n = R18n::I18n.new(%w[ru en], DIR)
     expect(i18n.in.another.level).to eq('Иерархический')


### PR DESCRIPTION
Capybara rev 63a12e7ba064fe326b36d014ede8c9269855a6af introduced some internal
changes that cause `to_hash` to be called on a `TranslatedString` when used as
such:

    expect(page).to have_no_content(thing.translated_field)

Given that `TranslatedString#method_missing` calls `get_untranslated`, Ruby is
unhappy about the result of the `to_hash` call, causing an exception.

Defining `TranslatedString#to_hash` to return `nil` fixes this.