### PR TITLE
Fix `TranslatedString#to_hash`

### DIFF
--- a/r18n-core/lib/r18n-core/untranslated.rb
+++ b/r18n-core/lib/r18n-core/untranslated.rb
@@ -75,6 +75,7 @@ module R18n
 
     NON_KEYS_METHODS = %i[
       to_ary
+      to_hash
       marshal_dump
       marshal_load
     ].freeze

--- a/r18n-core/spec/translation_spec.rb
+++ b/r18n-core/spec/translation_spec.rb
@@ -173,4 +173,14 @@ describe R18n::Translation do
     i18n = R18n::I18n.new('en', DIR)
     expect([i18n.one, i18n.two].flatten).to eq [i18n.one, i18n.two]
   end
+
+  it 'handles #to_hash' do
+    i18n = R18n::I18n.new('en', DIR)
+
+    def foo(*args, **opts)
+      [args, opts]
+    end
+
+    expect(foo(i18n.one)).to eq [[i18n.one], {}]
+  end
 end


### PR DESCRIPTION
For methods with double-splat, as in Cucumber.

Resolve #191