### PR TITLE
Allow upcased region in translation file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,6 @@ user:
     n: There are %1 users
 ```
 
-*Please note R18n files need to be lowercase `en-us.yml` and not `en-US.yml`.*
-
 To access translation you can call methods with the same names:
 
 ```ruby

--- a/r18n-core/README.md
+++ b/r18n-core/README.md
@@ -47,7 +47,8 @@ To set locale only for current thread use `R18n.thread_set`.
 
 Translation files are in YAML format by default and have names like
 `en.yml` (English) or `en-us.yml` (USA English dialect) with
-language/country code (RFC 3066).
+language/country code (RFC 3066). Upcased region (`en-US`) and
+`.yaml` file extension are also allowed.
 
 In your translation files you can use:
 

--- a/r18n-core/lib/r18n-core/yaml_loader.rb
+++ b/r18n-core/lib/r18n-core/yaml_loader.rb
@@ -56,7 +56,7 @@ module R18n
 
         translations = {}
         Dir.glob(
-          File.join(@dir, "**/#{locale.code.downcase}.#{FILE_EXT}")
+          File.join(@dir, "**/#{locale.code}.#{FILE_EXT}"), File::FNM_CASEFOLD
         ).each do |i|
           Utils.deep_merge!(translations, ::YAML.load_file(i) || {})
         end

--- a/r18n-core/spec/r18n_spec.rb
+++ b/r18n-core/spec/r18n_spec.rb
@@ -175,4 +175,17 @@ describe R18n do
     R18n.set('en')
     expect(t.one).to eq('One')
   end
+
+  it 'allows to load files with downcased region in name' do
+    R18n.default_places = File.join(TRANSLATIONS, 'yaml')
+    R18n.set('en-us')
+    expect(t.one).to eq('American One')
+  end
+
+  it 'allows to load files with upcased region in name' do
+    R18n.default_places = File.join(TRANSLATIONS, 'yaml')
+    R18n.set('en-gb')
+    expect(R18n.get.locale.code).to eq('en-GB')
+    expect(t.one).to eq('British One')
+  end
 end

--- a/r18n-core/spec/translations/yaml/en-GB.yml
+++ b/r18n-core/spec/translations/yaml/en-GB.yml
@@ -1,0 +1,1 @@
+one: British One

--- a/r18n-core/spec/translations/yaml/en-us.yml
+++ b/r18n-core/spec/translations/yaml/en-us.yml
@@ -1,0 +1,1 @@
+one: American One

--- a/r18n-core/spec/yaml_loader_spec.rb
+++ b/r18n-core/spec/yaml_loader_spec.rb
@@ -47,6 +47,8 @@ describe R18n::Loader::YAML do
     expect(loader.available).to match_array([
       R18n.locale('ru'),
       R18n.locale('en'),
+      R18n.locale('en-us'),
+      R18n.locale('en-gb'),
       R18n.locale('fr'),
       R18n.locale('notransl'),
       R18n.locale('nolocale')


### PR DESCRIPTION
`en-US.yml`, for example, along with `en-us.yml`.