### PR TITLE
Load `base` translations from parent locale

### DIFF
--- a/r18n-core/lib/r18n-core/i18n.rb
+++ b/r18n-core/lib/r18n-core/i18n.rb
@@ -244,6 +244,9 @@ module R18n
           if available.include? locale
             @translation.merge! extension.load(locale), locale
           end
+          if available.include? locale.parent
+            @translation.merge! extension.load(locale.parent), locale.parent
+          end
         end
       end
 

--- a/r18n-core/lib/r18n-core/locale.rb
+++ b/r18n-core/lib/r18n-core/locale.rb
@@ -109,14 +109,16 @@ module R18n
       end
     end
 
-    attr_reader :code, :language, :region
+    attr_reader :code, :language, :region, :parent
 
     def initialize
-      name = self.class.name.split('::').last
-      language, region = name.match(/([A-Z][a-z]+)([A-Z]\w+)?/).captures
+      language, region =
+        self.class.name.split('::').last.split(/([A-Z][a-z]+)/)[1, 2]
       @language = language.downcase.freeze
       @region = region.upcase.freeze if region
       @code = "#{@language}#{"-#{region}" if region}".freeze
+
+      @parent = self.class.superclass.new
     end
 
     set sublocales:  %w[en],

--- a/r18n-core/lib/r18n-core/yaml_loader.rb
+++ b/r18n-core/lib/r18n-core/yaml_loader.rb
@@ -46,7 +46,7 @@ module R18n
       # Array of locales, which has translations in +dir+.
       def available
         Dir.glob(File.join(@dir, "**/*.#{FILE_EXT}"))
-          .map { |i| File.basename(i, '.*') }.uniq
+          .map { |i| File.basename(i, '.*').downcase }.uniq
           .map { |i| R18n.locale(i) }
       end
 

--- a/r18n-core/spec/i18n_spec.rb
+++ b/r18n-core/spec/i18n_spec.rb
@@ -123,6 +123,11 @@ describe R18n::I18n do
     expect(i18n.two).to eq('Two')
   end
 
+  it 'loads base translations from parent locale' do
+    i18n = R18n::I18n.new('en-US', File.join(TRANSLATIONS, 'with_regions'))
+    expect(i18n.save).to eq('Save')
+  end
+
   it 'returns available translations' do
     i18n = R18n::I18n.new('en', DIR)
     expect(i18n.available_locales).to match_array([

--- a/r18n-core/spec/locales/en-us_spec.rb
+++ b/r18n-core/spec/locales/en-us_spec.rb
@@ -10,4 +10,11 @@ describe R18n::Locales::EnUS do
     expect(en_us.l(Date.parse('2009-05-11'), :full)).to eq('May 11th, 2009')
     expect(en_us.l(Date.parse('2009-05-21'), :full)).to eq('May 21st, 2009')
   end
+
+  it 'takes locaize from `en` locale when loaded from dir with only regions' do
+    en_us = R18n::I18n.new(
+      'en-US', File.join(__dir__, '..', 'translations', 'with_regions')
+    )
+    expect(en_us.l(Time.now - 61, :human)).to eq '1 minute ago'
+  end
 end


### PR DESCRIPTION
For example, load `en` base translations for `en-US` locale,
when `en` is unavailable in the directory with translation.