### PR TITLE
Downcase locales with regions for `Translated`

### DIFF
--- a/r18n-core/lib/r18n-core/locale.rb
+++ b/r18n-core/lib/r18n-core/locale.rb
@@ -109,7 +109,7 @@ module R18n
       end
     end
 
-    attr_reader :code, :language, :region, :parent
+    attr_reader :code, :language, :region, :downcased_code, :parent
 
     def initialize
       language, region =
@@ -117,6 +117,7 @@ module R18n
       @language = language.downcase.freeze
       @region = region.upcase.freeze if region
       @code = "#{@language}#{"-#{region}" if region}".freeze
+      @downcased_code = @code.downcase.tr('-', '_').freeze
 
       @parent = self.class.superclass.new
     end

--- a/r18n-core/lib/r18n-core/translated.rb
+++ b/r18n-core/lib/r18n-core/translated.rb
@@ -127,7 +127,7 @@ module R18n
           result = nil
 
           r18n.locales.each do |locale|
-            code = locale.code
+            code = locale.downcased_code
             next unless unlocalized.key? code
             result = send(
               unlocalized[code], *(params unless options[:no_params])

--- a/r18n-core/lib/r18n-core/unsupported_locale.rb
+++ b/r18n-core/lib/r18n-core/unsupported_locale.rb
@@ -24,10 +24,13 @@ module R18n
     # Locale, to get data and pluralization for unsupported locale.
     attr_accessor :base
 
+    attr_reader :code, :downcased_code
+
     # Create object for unsupported locale with +code+ and load other locale
     # data from +base+ locale.
     def initialize(code, _base = nil)
       @code = code
+      @downcased_code = @code.downcase.tr('-', '_').freeze
       @base = Locale.load(I18n.default) if @code != I18n.default
     end
 
@@ -40,9 +43,6 @@ module R18n
     def inspect
       "Unsupported locale #{@code}"
     end
-
-    # Locale RFC 3066 code.
-    attr_reader :code
 
     # Locale code as title.
     def title

--- a/r18n-core/spec/translated_spec.rb
+++ b/r18n-core/spec/translated_spec.rb
@@ -42,6 +42,22 @@ describe R18n::Translated do
     expect(user.name).to eq('Джон')
   end
 
+  it 'translates locales with regions' do
+    class SomeTranslatedClass
+      include R18n::Translated
+
+      def name_en_us
+        'John'
+      end
+
+      translation :name
+    end
+    obj = ::SomeTranslatedClass.new
+
+    R18n.set('en-US')
+    expect(obj.name).to eq('John')
+  end
+
   it 'returns TranslatedString' do
     class SomeTranslatedClass
       include R18n::Translated


### PR DESCRIPTION
Example: `Object#name_en_us` instead of `#name_en-US`.

Method names with `-` has problems with literal (you have to use `public_send`)
and something in Shrine gem (`eval`, I guess).