### PR TITLE
Drop Ruby 2.3 support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,6 @@
 test_task:
   container:
     matrix:
-      image: ruby:2.3
       image: ruby:2.4
       image: ruby:2.5
   bundle_cache:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,5 @@
 AllCops:
-  # Ruby 2.2 is now under the state of the security maintenance phase, until the end of the March of 2018. After the date, maintenance of Ruby 2.2 will be ended.
-  # https://www.ruby-lang.org/en/news/2017/12/14/ruby-2-2-9-released/
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.4
 
 Style/FrozenStringLiteralComment:
   EnforcedStyle: always

--- a/r18n-core/lib/r18n-core/locale.rb
+++ b/r18n-core/lib/r18n-core/locale.rb
@@ -121,7 +121,7 @@ module R18n
         self.class.name.split('::').last.split(/([A-Z][a-z]+)/)[1, 2]
       @language = language.downcase.freeze
       @region = region.upcase.freeze if region
-      @code = "#{@language}#{"-#{region}" if region}".freeze
+      @code = "#{@language}#{"-#{region}" if region}"
       @downcased_code = @code.downcase.tr('-', '_').freeze
 
       @parent = self.class.superclass.new
@@ -208,7 +208,7 @@ module R18n
     # It will also put real typographic minus.
     def format_integer(integer)
       str = integer.to_s
-      str[0] = '−' if integer < 0 # Real typographic minus
+      str[0] = '−' if integer.negative? # Real typographic minus
       group = number_group
 
       str.gsub(/(\d)(?=(\d\d\d)+(?!\d))/) do |match|
@@ -268,7 +268,7 @@ module R18n
         i18n.human_time.after_hours((diff / 60.0).floor)
       elsif minutes <= -60
         i18n.human_time.hours_ago((diff / 60.0).floor)
-      elsif minutes > 0
+      elsif minutes.positive?
         i18n.human_time.after_minutes(minutes.round)
       else
         i18n.human_time.minutes_ago(minutes.round.abs)

--- a/r18n-core/lib/r18n-core/locales/hu.rb
+++ b/r18n-core/lib/r18n-core/locales/hu.rb
@@ -30,7 +30,7 @@ module R18n
 
       def format_integer(integer)
         str = integer.to_s
-        str[0] = '−' if integer < 0 # Real typographic minus
+        str[0] = '−' if integer.negative? # Real typographic minus
         group = number_group
 
         # only group numbers if it has at least 5 digits

--- a/r18n-core/lib/r18n-core/version.rb
+++ b/r18n-core/lib/r18n-core/version.rb
@@ -2,5 +2,5 @@
 
 # Version of R18n Core
 module R18n
-  VERSION = '3.2.0'.freeze unless defined? R18n::VERSION
+  VERSION = '3.2.0' unless defined? R18n::VERSION
 end

--- a/r18n-core/lib/r18n-core/yaml_loader.rb
+++ b/r18n-core/lib/r18n-core/yaml_loader.rb
@@ -32,7 +32,7 @@ module R18n
     class YAML
       include ::R18n::YamlMethods
 
-      FILE_EXT = 'y{,a}ml'.freeze
+      FILE_EXT = 'y{,a}ml'
 
       # Dir with translations.
       attr_reader :dir


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/