### PR TITLE
Add `:with_seconds` option for Time formatting

### DIFF
--- a/r18n-core/lib/r18n-core/locale.rb
+++ b/r18n-core/lib/r18n-core/locale.rb
@@ -127,11 +127,12 @@ module R18n
       @parent = self.class.superclass.new
     end
 
-    set sublocales:  %w[en],
-        week_start:  :monday,
-        time_am:     'AM',
-        time_pm:     'PM',
-        time_format: '_ %H:%M',
+    set sublocales: %w[en],
+        week_start: :monday,
+        time_am: 'AM',
+        time_pm: 'PM',
+        time_format: '_ %R',
+        time_with_seconds_format: '_ %T',
         full_format: '%-d %B',
         year_format: '_ %Y'
 
@@ -249,8 +250,10 @@ module R18n
     end
 
     # Format +time+ and set +date+
-    def format_time(date, time)
-      strftime(time, time_format).sub('_', date.to_s)
+    def format_time(date, time, with_seconds: false)
+      strftime(
+        time, with_seconds ? time_with_seconds_format : time_format
+      ).sub('_', date.to_s)
     end
 
     # Format +time+ in human usable form. For example “5 minutes ago” or
@@ -276,14 +279,16 @@ module R18n
     end
 
     # Format +time+ in compact form. For example, “12/31/09 12:59”.
-    def format_time_standard(time, *_params)
-      format_time(format_date_standard(time), time)
+    def format_time_standard(time, *params)
+      options = params.last.is_a?(Hash) ? params.last : {}
+      format_time(format_date_standard(time), time, **options)
     end
 
     # Format +time+ in most official form. For example, “December 31st, 2009
     # 12:59”. For special cases you can replace it in locale’s class.
-    def format_time_full(time, *_params)
-      format_time(format_date_full(time), time)
+    def format_time_full(time, *params)
+      options = params.last.is_a?(Hash) ? params.last : {}
+      format_time(format_date_full(time), time, **options)
     end
 
     # Format +date+ in human usable form. For example “5 days ago” or

--- a/r18n-core/lib/r18n-core/locales/af.rb
+++ b/r18n-core/lib/r18n-core/locales/af.rb
@@ -22,7 +22,8 @@ module R18n
         date_format: '%d/%m/%Y',
         full_format: '%-d %B',
         year_format: '_, %Y',
-        time_format: '_, %H:%M',
+        time_format: '_, %R',
+        time_with_seconds_format: '_, %T',
 
         number_decimal: '.',
         number_group:   ','

--- a/r18n-core/lib/r18n-core/locales/az.rb
+++ b/r18n-core/lib/r18n-core/locales/az.rb
@@ -20,7 +20,6 @@ module R18n
         time_am:     ' gündüz',
         time_pm:     ' axşam',
         date_format: '%d.%m.%Y',
-        time_format: '_%H:%M',
 
         number_decimal: ',',
         number_group:   ' '

--- a/r18n-core/lib/r18n-core/locales/en-us.rb
+++ b/r18n-core/lib/r18n-core/locales/en-us.rb
@@ -11,6 +11,7 @@ module R18n
         sublocales: %w[en],
 
         time_format: '_ %I:%M %p',
+        time_with_seconds_format: '_ %r',
         date_format: '%m/%d/%Y',
         full_format: '%B %-d'
       )

--- a/r18n-core/lib/r18n-core/locales/es-us.rb
+++ b/r18n-core/lib/r18n-core/locales/es-us.rb
@@ -10,7 +10,8 @@ module R18n
         title: 'Español Estadounidense',
         sublocales: %w[es en],
 
-        time_format: ' %I:%M %p',
+        time_format: '_ %I:%M %p',
+        time_with_seconds_format: '_ %r',
         date_format: '%m/%d/%Y',
 
         number_decimal: '.',

--- a/r18n-core/lib/r18n-core/locales/fi.rb
+++ b/r18n-core/lib/r18n-core/locales/fi.rb
@@ -22,6 +22,7 @@ module R18n
         date_format: '%d.%m.%Y',
         full_format: '%-d. %B',
         time_format: '_ %H.%M',
+        time_with_seconds_format: '_ %H.%M.%S',
 
         number_decimal: ',',
         number_group:   ''

--- a/r18n-core/lib/r18n-core/locales/hu.rb
+++ b/r18n-core/lib/r18n-core/locales/hu.rb
@@ -18,7 +18,8 @@ module R18n
         date_format: '%Y. %m. %d.',
         full_format: '%B %-d.',
         year_format: '%Y. _',
-        time_format: '_, %H:%M',
+        time_format: '_, %R',
+        time_with_seconds_format: '_, %T',
 
         number_decimal: ',',
         number_group:   ' '

--- a/r18n-core/lib/r18n-core/locales/tr.rb
+++ b/r18n-core/lib/r18n-core/locales/tr.rb
@@ -17,7 +17,6 @@ module R18n
         date_format: '%d.%m.%Y',
         full_format: '%B %-d.',
         year_format: '%Y. _',
-        time_format: '_%H:%M',
 
         number_decimal: '.',
         number_group:   ','

--- a/r18n-core/lib/r18n-core/locales/vi.rb
+++ b/r18n-core/lib/r18n-core/locales/vi.rb
@@ -19,7 +19,8 @@ module R18n
         date_format: '%d/%m/%Y',
         full_format: 'ngày %-d %B',
         year_format: '_ năm %Y',
-        time_format: '%H:%M, _',
+        time_format: '%R, _',
+        time_with_seconds_format: '%T, _',
 
         number_decimal: '.',
         number_group:   ','

--- a/r18n-core/spec/i18n_spec.rb
+++ b/r18n-core/spec/i18n_spec.rb
@@ -241,11 +241,19 @@ describe R18n::I18n do
     expect(i18n.l(-123_456_789)).to eq('−123 456 789')
     expect(i18n.l(-12_345.67)).to   eq('−12 345,67')
 
-    time = Time.at(0).utc
-    expect(i18n.l(time, '%A')).to      eq('Четверг')
-    expect(i18n.l(time, :month)).to    eq('Январь')
-    expect(i18n.l(time, :standard)).to eq('01.01.1970 00:00')
-    expect(i18n.l(time, :full)).to     eq('1 января 1970 00:00')
+    time = Time.utc(2014, 5, 6, 7, 8, 9)
+    expect(i18n.l(time, '%A'))
+      .to eq('Вторник')
+    expect(i18n.l(time, :month))
+      .to eq('Май')
+    expect(i18n.l(time, :standard))
+      .to eq('06.05.2014 07:08')
+    expect(i18n.l(time, :standard, with_seconds: true))
+      .to eq('06.05.2014 07:08:09')
+    expect(i18n.l(time, :full))
+      .to eq('6 мая 2014 07:08')
+    expect(i18n.l(time, :full, with_seconds: true))
+      .to eq('6 мая 2014 07:08:09')
 
     expect(i18n.l(Date.new(0))).to eq('01.01.0000')
   end

--- a/r18n-core/spec/locales/af_spec.rb
+++ b/r18n-core/spec/locales/af_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+describe R18n::Locales::Af do
+  it 'formats Afrikaans time' do
+    af = R18n::I18n.new('af')
+    expect(af.l(Time.utc(2009, 5, 1, 6, 7, 8), :standard, with_seconds: true))
+      .to eq('01/05/2009, 06:07:08')
+  end
+end

--- a/r18n-core/spec/locales/en-us_spec.rb
+++ b/r18n-core/spec/locales/en-us_spec.rb
@@ -11,6 +11,14 @@ describe R18n::Locales::EnUS do
     expect(en_us.l(Date.parse('2009-05-21'), :full)).to eq('May 21st, 2009')
   end
 
+  it 'formats American English time' do
+    en_us = R18n::I18n.new('en-US')
+    expect(
+      en_us.l(Time.utc(2009, 5, 1, 6, 7, 8), :standard, with_seconds: true)
+    )
+      .to eq('05/01/2009 06:07:08 AM')
+  end
+
   it 'takes locaize from `en` locale when loaded from dir with only regions' do
     en_us = R18n::I18n.new(
       'en-US', File.join(__dir__, '..', 'translations', 'with_regions')

--- a/r18n-core/spec/locales/es-us_spec.rb
+++ b/r18n-core/spec/locales/es-us_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+describe R18n::Locales::EnUS do
+  it 'formats American Spanish time' do
+    es_us = R18n::I18n.new('es-US')
+    expect(
+      es_us.l(Time.utc(2009, 5, 1, 6, 7, 8), :standard, with_seconds: true)
+    )
+      .to eq('05/01/2009 06:07:08 AM')
+  end
+end

--- a/r18n-core/spec/locales/fi_spec.rb
+++ b/r18n-core/spec/locales/fi_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+describe R18n::Locales::Fi do
+  it 'formats Finnish time' do
+    fi = R18n::I18n.new('fi')
+    expect(fi.l(Time.utc(2009, 5, 1, 6, 7, 8), :standard, with_seconds: true))
+      .to eq('01.05.2009 06.07.08')
+  end
+end

--- a/r18n-core/spec/locales/hu_spec.rb
+++ b/r18n-core/spec/locales/hu_spec.rb
@@ -13,5 +13,7 @@ describe R18n::Locales::Hu do
     hu = R18n::I18n.new('hu')
     expect(hu.l(Time.at(0).utc)).to        eq('1970. 01. 01., 00:00')
     expect(hu.l(Time.at(0).utc, :full)).to eq('1970. január 1., 00:00')
+    expect(hu.l(Time.utc(2009, 5, 1, 6, 7, 8), :standard, with_seconds: true))
+      .to eq('2009. 05. 01., 06:07:08')
   end
 end

--- a/r18n-core/spec/locales/vi_spec.rb
+++ b/r18n-core/spec/locales/vi_spec.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 describe R18n::Locales::Vi do
-  it 'change times position' do
-    th = R18n::I18n.new('vi')
-    expect(th.l(Time.at(0).utc)).to eq('00:00, 01/01/1970')
+  it 'formats Vietnamese time' do
+    vi = R18n::I18n.new('vi')
+    expect(vi.l(Time.utc(2009, 5, 1, 6, 7, 8), :standard, with_seconds: true))
+      .to eq('06:07:08, 01/05/2009')
   end
 end


### PR DESCRIPTION
Example: `l Time.now, :standard, with_seconds: true # => '05.06.2019 13:31:42'`