### PR TITLE
Improve Indonesian translation

### DIFF
--- a/r18n-core/lib/r18n-core/locales/id.rb
+++ b/r18n-core/lib/r18n-core/locales/id.rb
@@ -11,10 +11,12 @@ module R18n
         wday_abbrs: %w[Min Sen Sel Rab Kam Jum Sab],
 
         month_names: %w[Januari Februari Maret April Mei Juni Juli Agustus
-                        September Oktober Nopember Desember],
-        month_abbrs: %w[Jan Feb Mar Apr Mei Jun Jul Agu Sep Okt Nop Des],
+                        September Oktober November Desember],
+        month_abbrs: %w[Jan Feb Mar Apr Mei Jun Jul Agu Sep Okt Nov Des],
 
         date_format: '%d/%m/%Y',
+        time_format: '_ pukul %H.%M',
+        time_with_seconds_format: '_ pukul %H.%M.%S',
 
         number_decimal: ',',
         number_group:   '.'

--- a/r18n-core/spec/locales/id_spec.rb
+++ b/r18n-core/spec/locales/id_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+describe R18n::Locales::Id do
+  it 'formats Indonesian date' do
+    id = R18n::I18n.new('id')
+
+    expect(id.l(Date.parse('2009-11-01'), :full)).to eq('1 November 2009')
+    expect(id.l(Date.parse('2009-11-02'), :standard)).to eq('02/11/2009')
+    expect(id.l(Date.parse('2009-11-21'), '%d/%b/%y')).to eq('21/Nov/09')
+  end
+
+  it 'formats Indonesian time' do
+    id = R18n::I18n.new('id')
+    time = id.l(Time.utc(2009, 5, 1, 6, 7, 8), :standard)
+    expect(time).to eq('01/05/2009 pukul 06.07')
+  end
+
+  it 'formats Indonesian time with seconds' do
+    id = R18n::I18n.new('id')
+    time = id.l(Time.utc(2009, 5, 1, 6, 7, 8), :standard, with_seconds: true)
+    expect(time).to eq('01/05/2009 pukul 06.07.08')
+  end
+end


### PR DESCRIPTION
Hi,

I want to add a couple improvements for Indonesian translation:
- Change 'Nopember' to 'November' ([it's the correct spelling](https://id.wikipedia.org/wiki/November)).
- Update time format to use dots as separator.
- Add tests.