### PR TITLE
Improve documentation

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -43,7 +43,7 @@
 ## 2.2 (La Habana)
 * Change date format in `en` locale to `YYYY-MM-DD` (by Alexander Popov).
 * Add `TranslatedString#as_json` for ActiveSupport compatibility (by Tim Craft).
-* Fix `TranslatedString#html_safe?` behaviour (by Tim Craft).
+* Fix `TranslatedString#html_safe?` behavior (by Tim Craft).
 * Fix unsupported `LANG` environment (by Chris Poirier).
 * Fix `Locale#localize` method for `DateTime` objects (by Alexander Popov).
 
@@ -97,7 +97,7 @@
 * Add JRuby 9000 support.
 
 ### 1.1.11 (São Paulo)
-* Allow to set Proc as `default` option in Rails I18n backend.
+* Allow to set Proc as `default` option in Rails I18n back-end.
 
 ### 1.1.10 (十)
 * Fix Esperanto locale by Larry Gilbert.
@@ -112,7 +112,7 @@
 
 ### 1.1.7 (Tujuh)
 * Return `nil` on untranslated in models with Translated.
-* Add `transliterate` method to I18n backend.
+* Add `transliterate` method to I18n back-end.
 * Add Indonesian locale (by Guntur Akhmad).
 
 ### 1.1.6 (Vitebsk)
@@ -120,17 +120,17 @@
 * Fix path in global String filters.
 
 ### 1.1.5 (Hilo)
-* Fix Sinatra plugin under multithreaded web-server (by Viktors Rotanovs).
-* Fix BigDecimal localizing (by François Beausoleil).
+* Fix Sinatra plugin under multi-threaded web-server (by Viktors Rotanovs).
+* Fix `BigDecimal` localizing (by François Beausoleil).
 * Add American American Spanish locale (by renemarcelo).
 
 ### 1.1.4 (Bokmål)
-* Add Norwegian “no” locale as gateway to Bokmål or Nynorsk.
+* Add Norwegian `no` locale as gateway to Bokmål or Nynorsk.
 * Fix Norwegian Bokmål locale code.
-* Fix hungarian time format (Kővágó Zoltán).
+* Fix Hungarian time format (Kővágó Zoltán).
 
 ### 1.1.3 (Saint Petersburg)
-* Fix memory leak from cache key missmatch in Rails plugin (by silentshade).
+* Fix memory leak from cache key mismatch in Rails plugin (by silentshade).
 
 ### 1.1.2 (Marshal)
 * Fix translation and untranslated marshalizing (by silentshade).
@@ -138,27 +138,27 @@
 * Fix untranslated strings output in tests.
 
 ### 1.1.1 (Dunhuang)
-* Don’t change YAML parser in Ruby 1.9.
-* Allow to change locale by argument in R18n Rails backend.
-* Set also Rails I18n locale in Rails autodetect filter.
+* Don't change YAML parser in Ruby 1.9.
+* Allow to change locale by argument in R18n Rails back-end.
+* Set also Rails I18n locale in Rails auto-detect filter.
 * Fix caching with custom filters (by Anton Onyshchenko).
 * Fix translation variables with `%1` text inside (by Taras Kunch).
 * Fix Latvian locale (by Aleksandrs Ļedovskis).
 
 ### 1.1.0 (Leipzig)
 * A lot of fixes in Rails I18n compatibility (thanks for Stephan Schubert).
-* Return Untranslted, when user try to call another translation key on
+* Return `Untranslted`, when user try to call another translation key on
   already translated string.
 * Add `Translation#to_hash` to get raw translation.
 * Add `Translation#inspect` to easy debug.
-* Return translation, when pluralization filter didn’t get count.
-* Set R18n backend on Rails plugin init, to use it in console.
+* Return translation, when pluralization filter did not get count.
+* Set R18n back-end on Rails plugin init, to use it in console.
 * Allow to use Integer in translation keys.
 
 ### 1.0.1 (Phuket Town)
 * Fix translation reloading in Rails and Sinatra.
 * Use global R18n settings for Sinatra extension.
-* Allow to override desktop autodetect by LANG environment on all platforms.
+* Allow to override desktop auto-detect by LANG environment on all platforms.
 * Add support for JRuby in 1.9 mode.
 * Rename `R18n.reset` to `R18n.reset!` and add `R18n.clear_cache!`.
 * Fix Sinatra with loaded ActiveSupport.
@@ -166,7 +166,7 @@
 
 ### 1.0.0 (Bangkok)
 * Add `R18n.default_places`.
-* Rails SafeBuffer support.
+* Rails `SafeBuffer` support.
 * Allow in Rails app to put filters to `app/i18n` reload them in development.
 * Move `R18n::I18n.available_locales` to `R18n.available_locales`.
 * Rename `_keys` to `translation_keys`.
@@ -191,11 +191,11 @@
 * Fix Swedish locale (by Pär Wieslander).
 
 ### 0.4.13 (Sti)
-* Fix Pathname to String error in r18n-desktop.
+* Fix `Pathname` to `String` error in `r18n-desktop`.
 * Add Norwegian locale (by Oddmund Strømme).
 
 ### 0.4.12 (Шлях)
-* Fix Pathname to String convertion error.
+* Fix `Pathname` to `String` conversion error.
 * Fix model translation for non-ActiveRecord (by Szymon Przybył).
 * Add Ukrainian locale (by Ярослав Руденок).
 
@@ -225,14 +225,14 @@
 * Fix caching issue (by Viktors Rotanovs).
 * Add Danish locale (by Hans Czajkowski Jørgensen)
 * Fix Italian locale (by Viktors Rotanovs).
-* Move untranslated filters with html highlight to r18n-core.
+* Move untranslated filters with html highlight to `r18n-core`.
 
 ### 0.4.7.1 (Kyū)
 * Fix Japanese locale in Ruby 1.9.1.
 
 ### 0.4.7 (Mado)
-* Fix autodetect locale in Windows and Ruby 1.9.1 (by Marvin Gülker).
-* Fix autodetect locale in JRuby (by Kővágó, Zoltán).
+* Fix auto-detect locale in Windows and Ruby 1.9.1 (by Marvin Gülker).
+* Fix auto-detect locale in JRuby (by Kővágó, Zoltán).
 * Fix human time format on 60 minutes.
 * Add Hungarian locale (by Kővágó, Zoltán).
 * Add Japanese locale (by hryk).
@@ -260,7 +260,7 @@
 * Set I18n object to thread (by Simon Hafner).
 * Add to l Rails helper R18n syntax.
 * Add common helpers.
-* Clear cache in R18n.reset.
+* Clear cache in `R18n.reset`.
 * Clean up code and fix bug (by Akzhan Abdulin).
 * Add Thai locale (by Felix Hanley).
 
@@ -277,7 +277,7 @@
 
 ### 0.4.1 (Lazy Boole)
 * Add passive filters.
-* Receive filter position as option Hash.
+* Receive filter position as option `Hash`.
 * Fix base translations (by Pavel Kunc).
 
 ### 0.4 (D-Day)
@@ -304,25 +304,25 @@
 * Remove RubyGems requires.
 
 ### 0.3 (Vladivostok)
-* Translated mixin to add i18n support to model or any other class.
+* `Translated` mix-in to I18n support to model or any other class.
 * New cool time formatters.
 * Filters for translations.
 * Add filters to escape HTML, Markdown and Textile syntax.
 * Pluralization and variables is now filters and can be replaced.
 * I18n#locales now contain all detected locales, used to load translations,
   instead of just received from user.
-* Bugfix in locale code case.
+* Bug-fix in locale code case.
 * Add Czech locale (by Josef Pospíšil).
 
 ### 0.2.3 (Shanghai eclipse)
-* R18n will return path string if translation isn’t exists.
-* Add UnsupportedLocale class for locale without information file.
+* R18n will return path string if translation isn't exists.
+* Add `UnsupportedLocale` class for locale without information file.
 * Load absent locale information from default locale.
 * Add Polish locale (by Tymon Tobolski).
 
 ### 0.2.2 (Clone Wars)
 * Localize numbers in pluralization.
-* Bugfix in translation variables.
+* Bug-fix in translation variables.
 
 ### 0.2.1 (Neun)
 * Ruby 1.9 compatibility.
@@ -336,8 +336,8 @@
 * Add Kazakh locale.
 
 ### 0.1.1 (Saluto)
-* Loading i18n object without translations.
+* Loading I18n object without translations.
 * Add output for standalone month name.
-* Don’t call procedures from translations if it isn’t secure.
+* Don't call procedures from translations if it isn't secure.
 * Add Esperanto locale.
 * English locale now contain UK date standards.

--- a/README.md
+++ b/README.md
@@ -53,16 +53,16 @@ For Rails, Sinatra or desktop examples, see plugins documentations:
 * [sinatra-r18n] for Sinatra,
 * [r18n-desktop] for shell/desktop applications.
 
-[r18n-rails]: https://github.com/ai/r18n/tree/master/r18n-rails
-[sinatra-r18n]: https://github.com/ai/r18n/tree/master/sinatra-r18n
-[r18n-desktop]: https://github.com/ai/r18n/tree/master/r18n-desktop
+[r18n-rails]: https://github.com/r18n/r18n/tree/master/r18n-rails
+[sinatra-r18n]: https://github.com/r18n/r18n/tree/master/sinatra-r18n
+[r18n-desktop]: https://github.com/r18n/r18n/tree/master/r18n-desktop
 
 ## R18n Features
 
 * Nice Ruby-style syntax.
 * Filters.
 * Model Translation (or any Ruby object).
-* Autodetect user locales.
+* Auto-detect user locales.
 * Flexible locales.
 * Total flexibility.
 
@@ -106,7 +106,7 @@ syntax.
 
 You can add filters for some YAML type. For example, we add custom filter to
 return different translation depend on user gender
-(it’s actual for some languages).
+(it's actual for some languages).
 
 ```yaml
 log:
@@ -140,12 +140,12 @@ i18n.greater #=> "1 &lt; 2 is true"
 ```
 
 You can also add filters for all returned translations or to issues, when
-translation can’t be founded.
+translation can't be founded.
 
 ### Model Translation
 
-You can translate any class, including ORM models (ActiveRecord, Mongoid,
-MongoMapper, DataMapper or others):
+You can translate any class, including ORM models (`ActiveRecord`, `Sequel`,
+`Mongoid`, `MongoMapper`, `DataMapper` or others):
 
 ```ruby
 class Product < ActiveRecord::Base
@@ -161,12 +161,13 @@ R18n.set('ru') # Russian
 product.title  #=> "Сибирская язва"
 ```
 
-### Autodetect User Locales
+### Auto-detect User Locales
 
 R18n has an agnostic core package and plugins with standard support for
 Sinatra and desktop applications. So for common cases you can use out-of-box
-gems with user locale autodetect. For special cases you can use core gem and
-hack everything, that you want (see “Total flexibility” section).
+gems with user locale auto-detect. For special cases you can use core gem and
+hack everything, that you want (see ["Total flexibility"](#total-flexibility)
+section).
 
 R18n automatically generate fallbacks for current user, based on
 user locales list from `HTTP_ACCEPT_LANGUAGE`, locale info (in some countries
@@ -202,7 +203,7 @@ l Time.now, :full         #=> "1er décembre 2011 12:00"
 l Time.now + 1.day, :full #=> "2 décembre 2011 12:00"
 ```
 
-Years in Thailand are counted in the Buddhist Era. It’s very easy for R18n:
+Years in Thailand are counted in the Buddhist Era. It's very easy for R18n:
 
 ```ruby
 R18n.set('th')
@@ -214,9 +215,9 @@ R18n.l Time.now, :full #=> "1 พฤศจิกายน, 2554 12:00"
 R18n is very flexible and agnostic. For example, Rails I18n compatibility level
 is just few filters and custom loader.
 
-Translation variables and pluralization (“1 comment”, “5 comments”) are filters
+Translation variables and pluralization ("1 comment", "5 comments") are filters
 too, so you can disable, replace or cascade them. For example, you can use the
-“named variables filter” from the `r18n-rails-api` gem:
+"named variables filter" from the `r18n-rails-api` gem:
 
 ```yaml
 greeting: "Hi, %{name}"
@@ -268,10 +269,12 @@ plugin_i18n.t.message.hellow
 
 ## Services
 
-* [WebTranslateIt] – web service to translate your app. It allow your customer
-  without programming skills help you with translations.
+* [Crowdin] — supports all of R18n, including pluralization, filters, etc.
 * [Localeapp] – Locale helps content owners and translators work together,
   so Rails developers are free to write more code.
+* [WebTranslateIt] – web service to translate your app. It allow your customer
+  without programming skills help you with translations.
 
-[WebTranslateIt]: https://webtranslateit.com/
+[Crowdin]: https://crowdin.com/
 [Localeapp]: http://www.localeapp.com/
+[WebTranslateIt]: https://webtranslateit.com/

--- a/r18n-core/README.md
+++ b/r18n-core/README.md
@@ -14,7 +14,7 @@ Use `r18n-rails` or `sinatra-r18n` to localize Web applications and
 * Flexible locales.
 * Total flexibility.
 
-See full features in [main README](https://github.com/ai/r18n/blob/master/README.md).
+See full features in [main README](https://github.com/r18n/r18n/blob/master/README.md).
 
 ## Usage
 
@@ -97,7 +97,7 @@ t.post.add     #=> "Add post"
 t[:post][:add] #=> "Add post"
 ```
 
-If the locale isn’t found in the user’s requested locale, R18n will search for
+If the locale isn't found in the user's requested locale, R18n will search for
 it in sublocales or in another locale, which the user also can accept:
 
 ```ruby
@@ -105,7 +105,7 @@ t.not.in.english #=> "В английском нет"
 ```
 
 The translated string has a `locale` method for determining its locale (Locale
-instance or code string if locale is’t supported in R18n):
+instance or code string if locale is't supported in R18n):
 
 ```ruby
 i18n.not.in.english.locale #=> Locale ru (Русский)
@@ -129,8 +129,8 @@ t.robots(1)  #=> "One robot"
 t.robots(50) #=> "50 robots"
 ```
 
-If there isn’t a pluralization for a particular number, translation will be use
-`n`. If there isn’t a locale file for translation, it will use the English
+If there isn't a pluralization for a particular number, translation will be use
+`n`. If there isn't a locale file for translation, it will use the English
 pluralization rule (`0`, `1` and `n`).
 
 You can check if the key has a translation:
@@ -194,7 +194,7 @@ To create a filter you pass the following to `R18n::Filters.add`:
 * Optional filter name, to disable, enable or delete it later by
   `R18n::Filters.off`, `R18n::Filters.on` and
   `R18n::Filters.delete`.
-* Hash with options:
+* `Hash` with options:
   * `passive: true` to filter translations only on load;
   * `:position` within the list of current filters of this type
     (by default a new filter will be inserted into last position).
@@ -202,7 +202,7 @@ To create a filter you pass the following to `R18n::Filters.add`:
 The filter will receive at least two arguments:
 * Translation (possibly already filtered by other filters for this type earlier
   in the list).
-* A Hash with translation `locale` and `path`.
+* A `Hash` with translation `locale` and `path`.
 * Parameters from translation request will be in the remaining arguments.
 
 In Rails application put your filters to `app/i18n/filters.rb`, it will be
@@ -255,7 +255,7 @@ hi: !!markdown
 t.hi #=> "<p><strong>Hi</strong>, people!</p>"
 ```
 
-If you can’t use Kramdown you can redefine Markdown filter
+If you can't use Kramdown you can redefine Markdown filter
 to use your own parser:
 
 ```ruby
@@ -312,8 +312,8 @@ l -12000.5 #=> "−12,000.5"
 Number and float formatters will also put real typographic minus and put
 non-breakable thin spaces (for locale, which use it as digit separator).
 
-You can translate months and week day names in Time, Date and DateTime by the
-`strftime` method:
+You can translate months and week day names in `Time`, `Date` and `DateTime`
+by the `strftime` method:
 
 ```ruby
 l Time.now, '%B'  #=> "September"
@@ -362,9 +362,9 @@ See `R18n::Translated` for documentation.
 
 ### Locale
 
-All supported locales are stored in R18n gem in `locales` directory. If you want
-to add your locale, please fork this project and send a pull request or email me
-at <andrey@sitnik.ru>.
+All supported locales are stored in `r18n-core` gem in `locales/` directory.
+If you want to add your locale, please see the ["Add Locale"](#add-locale)
+section.
 
 To get information about a locale create an `R18n::Locale` instance:
 
@@ -399,7 +399,7 @@ You can load translations from anywhere, not just from YAML files. To load
 translation you must create loader class with 2 methods:
 
 * `available` – return array of locales of available translations;
-* `load(locale)` – return Hash of translation.
+* `load(locale)` – return `Hash` of translation.
 
 Pass its instance to `R18n.default_places` or `R18n.set(locales, loaders)`
 
@@ -449,25 +449,29 @@ R18n.extension_places << R18n::Loader::YAML.new('./error_messages/')
 
 ## Add Locale
 
-If R18n hasn’t got locale file for your language, please add it. It’s very
+If R18n has not got locale file for your language, please add it. It's very
 simple:
 
-* Create the file <tt><i>code</i>.rb</tt> in the `locales/` directory for your
-  language and describe locale. Just copy from another locale and change the
+* Create the file `%{code}.rb` for your language and describe locale, then
+  require it in the project. Just copy from another locale and change the
   values.
   * If your country has alternate languages (for example, in exUSSR countries
     most people also know Russian), add
-    <tt>sublocales %w[<i>another_locale</i> en]</tt>.
-* Create in `base/` file <tt><i>code</i>.yml</tt>  for your language and
-  translate the base messages. Just copy file from language, which you know,
-  and rewrite values.
+    `sublocales %w[%{another_locale} en]`.
 * If your language needs some special logic (for example, different
   pluralization or time formatters) you can extend `R18n::Locale` class methods.
-* Send a pull request via GitHub <http://github.com/ai/r18n> or just write email
-  with the files to me <andrey@sitnik.ru>.
 
-*Code* is RFC 3066 code for your language (for example, “en” for English and
-“fr-CA” for Canadian French). Email me with any questions you may have, you will
+If you want to send a pull request:
+
+* Move your `%{code}.rb` file in the `locales/` directory.
+* Create `%{code}.yml` file for your language in the `base/` directory and
+  translate the base messages. Just copy file from language, which you know,
+  and rewrite values.
+* Send a pull request via GitHub <http://github.com/r18n/r18n> or just write
+  email with the files to <andrey@sitnik.ru> or <alex.wayfer@gmail.com>.
+
+`%{code}` is RFC 3066 code for your language (for example, `en` for English and
+`fr-CA` for Canadian French). Email me with any questions you may have, you will
 find other contact addresses at http://sitnik.ru.
 
 ## License

--- a/r18n-core/lib/r18n-core.rb
+++ b/r18n-core/lib/r18n-core.rb
@@ -39,8 +39,8 @@ module R18n
   autoload :Translated, 'r18n-core/translated'
 
   class << self
-    # Set I18n object globally. You can miss translation +places+, it will be
-    # taken from <tt>R18n.default_places</tt>.
+    # Set I18n object globally. You can miss translation `places`, it will be
+    # taken from `R18n.default_places`.
     def set(i18n = nil, places = R18n.default_places, &block)
       @i18n =
         if block_given?
@@ -90,17 +90,17 @@ module R18n
       Thread.current
     end
 
-    # Translate message. Alias for <tt>R18n.get.t</tt>.
+    # Translate message. Alias for `R18n.get.t`.
     def t(*params)
       get.t(*params)
     end
 
-    # Localize object. Alias for <tt>R18n.get.l</tt>.
+    # Localize object. Alias for `R18n.get.l`.
     def l(*params)
       get.l(*params)
     end
 
-    # Return I18n object for +locale+. Useful to temporary change locale,
+    # Return I18n object for `locale`. Useful to temporary change locale,
     # for example, to show text in locales list:
     #
     #   - R18n.available_locales.each do |locale|
@@ -126,19 +126,19 @@ module R18n
       i18n
     end
 
-    # Return Locale object by locale code. It’s shortcut for
-    # <tt>R18n::Locale.load(code)</tt>.
+    # Return Locale object by locale code. It's shortcut for
+    # `R18n::Locale.load(code)`.
     def locale(code)
       R18n::Locale.load(code)
     end
 
-    # Return Array of locales with available translations. You can miss
-    # translation +places+, it will be taken from <tt>R18n.default_places</tt>.
+    # Return `Array` of locales with available translations. You can miss
+    # translation `places`, it will be taken from `R18n.default_places`.
     def available_locales(places = R18n.default_places)
       R18n::I18n.convert_places(places).map(&:available).flatten.uniq
     end
 
-    # Default places for <tt>R18n.set</tt> and <tt>R18n.available_locales</tt>.
+    # Default places for `R18n.set` and `R18n.available_locales`.
     #
     # You can set block to calculate places dynamically:
     #   R18n.default_places { settings.i18n_places }
@@ -154,15 +154,15 @@ module R18n
       end
     end
 
-    # Default loader class, which will be used if you didn’t send loader to
-    # +I18n.new+ (object with +available+ and +load+ methods).
+    # Default loader class, which will be used if you didn't send loader to
+    # `I18n.new` (object with `available` and `load` methods).
     attr_accessor :default_loader
 
     # Loaders with extension translations. If application translations with
-    # same locale isn’t exists, extension file willn’t be used.
+    # same locale isn't exists, extension file willn't be used.
     attr_accessor :extension_places
 
-    # Hash of hash-like (see Moneta) object to store loaded translations.
+    # `Hash` of hash-like (see Moneta) object to store loaded translations.
     attr_accessor :cache
   end
 

--- a/r18n-core/lib/r18n-core/filter_list.rb
+++ b/r18n-core/lib/r18n-core/filter_list.rb
@@ -18,10 +18,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 module R18n
-  # Superclass for +GlobalFilterList+ and +CustomFilterList+ with filters
+  # Superclass for `GlobalFilterList` and `CustomFilterList` with filters
   # processing.
   class FilterList
-    # Process +value+ by filters in +enabled+.
+    # Process `value` by filters in `enabled`.
     def process(filters_type, type, value, locale, path, params)
       config = { locale: locale, path: path }
 
@@ -49,7 +49,7 @@ module R18n
       )
     end
 
-    # Process +value+ by global filters in +enabled+.
+    # Process `value` by global filters in `enabled`.
     def process_string(filters_type, value, config, params)
       config = { locale: value.locale, path: config } if config.is_a? String
 
@@ -64,7 +64,7 @@ module R18n
       end
     end
 
-    # Array of enabled filters with +filters_type+ for +type+.
+    # `Array` of enabled filters with `filters_type` for `type`.
     def enabled(filters_type, type)
       if filters_type == :passive
         passive(type)

--- a/r18n-core/lib/r18n-core/filters.rb
+++ b/r18n-core/lib/r18n-core/filters.rb
@@ -42,14 +42,14 @@ module R18n
   #
   #   i18n.filtered('_') #=> "This_content_will_be_processed_by_filter!"
   #
-  # Use String class as type to add global filter for all translated strings:
+  # Use `String` class as type to add global filter for all translated strings:
   #
   #   R18n::Filters.add(String, :escape_html) do |content, config, params|
   #     escape_html(content)
   #   end
   #
   # Filter config contain two parameters: translation locale and path. But it is
-  # Hash and you can add you own parameter to cross-filter communications:
+  # `Hash` and you can add you own parameter to cross-filter communications:
   #
   #   R18n::Filters.add(String, :hide_truth) do |content, config|
   #     return content if config[:censorship_check]
@@ -74,28 +74,28 @@ module R18n
   #   i18n.filtered('_') #=> "This_content_will_be_processed_by_filter!"
   #   R18n::Filters.delete(:no_space)
   #
-  # You can enabled/disabled filters only for special I18n object:
+  # You can enabled/disabled filters only for special `I18n` object:
   #
   #   R18n::I18n.new('en', nil, on_filters: [:untranslated_html, :no_space],
   #                             off_filters: :untranslated )
   module Filters
     class << self
-      # Hash of filter names to Filters.
+      # `Hash` of filter names to Filters.
       attr_accessor :defined
 
-      # Hash of types to all Filters.
+      # `Hash` of types to all Filters.
       attr_accessor :by_type
 
-      # Hash of types to enabled active filters.
+      # `Hash` of types to enabled active filters.
       attr_accessor :active_enabled
 
-      # Hash of types to enabled passive filters.
+      # `Hash` of types to enabled passive filters.
       attr_accessor :passive_enabled
 
-      # Hash of types to enabled passive and active filters.
+      # `Hash` of types to enabled passive and active filters.
       attr_accessor :enabled
 
-      # Rebuild +active_enabled+ and +passive_enabled+ for +type+.
+      # Rebuild `active_enabled` and `passive_enabled` for `type`.
       def rebuild_enabled!(type)
         @passive_enabled[type] = []
         @active_enabled[type] = []
@@ -113,17 +113,17 @@ module R18n
         end
       end
 
-      # Add new filter for +type+ with +name+ and return filter object. You
-      # can use String class as +type+ to add global filter for all translated
+      # Add new filter for `type` with `name` and return filter object. You
+      # can use `String` class as `type` to add global filter for all translated
       # string.
       #
-      # Filter content will be sent to +block+ as first argument, struct with
+      # Filter content will be sent to `block` as first argument, struct with
       # config as second and filters parameters will be in next arguments.
       #
       # Options:
-      # * +position+ – change order on processing several filters for same type.
+      # * `position` – change order on processing several filters for same type.
       #    Note that passive filters will be always run before active.
-      # * +passive+ – if +true+, filter will process only on translation
+      # * `passive` – if `true`, filter will process only on translation
       #   loading. Note that you must add all passive before load translation.
       def add(types, name = nil, options = {}, &block)
         if name.is_a? Hash
@@ -162,7 +162,7 @@ module R18n
         filter
       end
 
-      # Delete +filter+ by name or Filter object.
+      # Delete `filter` by name or Filter object.
       def delete(filter)
         filter = @defined[filter] unless filter.is_a? Filter
         return unless filter
@@ -174,7 +174,7 @@ module R18n
         end
       end
 
-      # Disable +filter+ by name or Filter object.
+      # Disable `filter` by name or Filter object.
       def off(filter)
         filter = @defined[filter] unless filter.is_a? Filter
         return unless filter
@@ -183,7 +183,7 @@ module R18n
         filter.types.each { |type| rebuild_enabled! type }
       end
 
-      # Turn on disabled +filter+ by name or Filter object.
+      # Turn on disabled `filter` by name or Filter object.
       def on(filter)
         filter = @defined[filter] unless filter.is_a? Filter
         return unless filter
@@ -192,7 +192,7 @@ module R18n
         filter.types.each { |type| rebuild_enabled! type }
       end
 
-      # Return filters, which be added inside +block+.
+      # Return filters, which be added inside `block`.
       def listen(&_block)
         filters = []
         @new_filter_listener = proc { |i| filters << i }

--- a/r18n-core/lib/r18n-core/helpers.rb
+++ b/r18n-core/lib/r18n-core/helpers.rb
@@ -32,12 +32,12 @@ module R18n
     end
     alias i18n r18n
 
-    # Translate message. Alias for <tt>r18n.t</tt>.
+    # Translate message. Alias for `r18n.t`.
     def t(*params)
       R18n.get.t(*params)
     end
 
-    # Localize object. Alias for <tt>r18n.l</tt>.
+    # Localize object. Alias for `r18n.l`.
     def l(*params)
       R18n.get.l(*params)
     end

--- a/r18n-core/lib/r18n-core/i18n.rb
+++ b/r18n-core/lib/r18n-core/i18n.rb
@@ -24,14 +24,14 @@ module R18n
   # Locale classes and create pretty way to use it.
   #
   # To get translation you can use same with Translation way – use method with
-  # translation’s name or <tt>[name]</tt> method. Translations will be also
-  # loaded for default locale, +sublocales+ from first in +locales+ and general
-  # languages for dialects (it will load +fr+ for +fr_CA+ too).
+  # translation's name or `[name]` method. Translations will be also
+  # loaded for default locale, `sublocales` from first in `locales` and general
+  # languages for dialects (it will load `fr` for `fr_CA` too).
   #
   # Translations will loaded by loader object, which must have 2 methods:
-  # * <tt>available</tt> – return array of locales of available translations;
-  # * <tt>load(locale)</tt> – return Hash of translation.
-  # If you will use default loader (+R18n.default_loader+) you can pass to I18n
+  # * `available` – return array of locales of available translations;
+  # * `load(locale)` – return Hash of translation.
+  # If you will use default loader (`R18n.default_loader`) you can pass to I18n
   # only constructor argument for loader:
   #
   #   R18n::I18n.new('en', R18n::Loader::YAML.new('dir/with/translations'))
@@ -41,16 +41,16 @@ module R18n
   #   R18n::I18n.new('en', 'dir/with/translations')
   #
   # In translation file you can use strings, numbers, floats (any YAML types)
-  # and pluralizable values (<tt>!!pl</tt>). You can use params in string
-  # values, which you can replace in program. Just write <tt>%1</tt>,
-  # <tt>%2</tt>, etc and set it values as method arguments, when you will be get
+  # and pluralizable values (`!!pl`). You can use params in string
+  # values, which you can replace in program. Just write `%1`,
+  # `%2`, etc and set it values as method arguments, when you will be get
   # value.
   #
   # You can use filters for some YAML type or for all strings. See R18n::Filters
   # for details.
   #
-  # R18n contain translations for common words (such as “OK”, “Cancel”, etc)
-  # for most supported locales. See <tt>base/</tt> dir.
+  # R18n contain translations for common words (such as "OK", "Cancel", etc)
+  # for most supported locales. See `base/` dir.
   #
   # == Usage
   # translations/ru.yml
@@ -105,7 +105,7 @@ module R18n
         locales.map! { |i| i[0] }
       end
 
-      # Load default loader for elements in +places+ with only constructor
+      # Load default loader for elements in `places` with only constructor
       # argument.
       def convert_places(places)
         Array(places).map! do |loader|
@@ -127,13 +127,13 @@ module R18n
     # First locale with locale file
     attr_reader :locale
 
-    # Create i18n for +locales+ with translations from +translation_places+ and
+    # Create i18n for `locales` with translations from `translation_places` and
     # locales data. Translations will be also loaded for default locale,
-    # +sublocales+ from first in +locales+ and general languages for dialects
-    # (it will load +fr+ for +fr_CA+ too).
+    # `sublocales` from first in `locales` and general languages for dialects
+    # (it will load `fr` for `fr_CA` too).
     #
-    # +Locales+ must be a locale code (RFC 3066) or array, ordered by priority.
-    # +Translation_places+ must be a string with path or array.
+    # `locales` must be a locale code (RFC 3066) or array, ordered by priority.
+    # `translation_places` must be a string with path or array.
     def initialize(locales, translation_places = nil, opts = {})
       locales = Array(locales)
 
@@ -252,18 +252,18 @@ module R18n
       R18n.cache[translation_cache_key] = [@locale, @translation]
     end
 
-    # Return Array of locales with available translations.
+    # Return `Array` of locales with available translations.
     def available_locales
       @available_locales ||= R18n.available_locales(@translation_places)
     end
 
-    # Convert +object+ to String, according to the rules of the current locale.
-    # It support Integer, Float, Time, Date and DateTime.
+    # Convert `object` to `String`, according to the rules of the current
+    # locale. It support `Integer`, `Float`, `Time`, `Date` and `DateTime`.
     #
-    # For time classes you can set +format+ in standard +strftime+ form,
-    # <tt>:full</tt> (“01 Jule, 2009”), <tt>:human</tt> (“yesterday”),
-    # <tt>:standard</tt> (“07/01/09”) or <tt>:month</tt> for standalone month
-    # name. Default format is <tt>:standard</tt>.
+    # For time classes you can set `format` in standard `strftime` form,
+    # `:full` ("01 Jule, 2009"), `:human` ("yesterday"),
+    # `:standard` ("07/01/09") or `:month` for standalone month
+    # name. Default format is `:standard`.
     #
     #   i18n.l -12000.5         #=> "−12,000.5"
     #   i18n.l Time.now         #=> "07/01/09 12:59"
@@ -280,10 +280,10 @@ module R18n
       @translation
     end
 
-    # Return translation with special +name+.
+    # Return translation with special `name`.
     #
-    # Translation can contain variable part. Just set is as <tt>%1</tt>,
-    # <tt>%2</tt>, etc in translations file and set values in next +params+.
+    # Translation can contain variable part. Just set is as `%1`,
+    # `%2`, etc in translations file and set values in next `params`.
     def [](name, *params)
       @translation[name, *params]
     end

--- a/r18n-core/lib/r18n-core/locale.rb
+++ b/r18n-core/lib/r18n-core/locale.rb
@@ -23,14 +23,14 @@ require 'bigdecimal'
 module R18n
   # Information about locale (language, country and other special variant
   # preferences). Locale was named by RFC 3066. For example, locale for French
-  # speaking people in Canada will be +fr-CA+.
+  # speaking people in Canada will be `fr-CA`.
   #
-  # Locale classes are placed in <tt>R18n::Locales</tt> module and storage
-  # install <tt>locales/</tt> dir.
+  # Locale classes are placed in `R18n::Locales` module and storage
+  # install `locales/` dir.
   #
-  # Each locale has +sublocales+ – often known languages for people from this
+  # Each locale has `sublocales` – often known languages for people from this
   # locale. For example, many Belorussians know Russian and English. If there
-  # is’t translation for Belorussian, it will be searched in Russian and next in
+  # is't translation for Belorussian, it will be searched in Russian and next in
   # English translations.
   #
   # == Usage
@@ -44,20 +44,20 @@ module R18n
   #
   # == Available data
   #
-  # * +code+ – locale RFC 3066 code;
-  # * +title+ – locale name on it language;
-  # * +ltr?+ – true on left-to-right writing direction, false for Arabic and
+  # * `code` – locale RFC 3066 code;
+  # * `title` – locale name on it language;
+  # * `ltr?` – true on left-to-right writing direction, false for Arabic and
   #   Hebrew);
-  # * +sublocales+ – often known languages for people from this locale;
-  # * +week_start+ – does week start from +:monday+ or +:sunday+.
+  # * `sublocales` – often known languages for people from this locale;
+  # * `week_start` – does week start from `:monday` or `:sunday`.
   #
   # You can see more available data about locale in samples in
-  # <tt>locales/</tt> dir.
+  # `locales/` dir.
   class Locale
     @loaded = {}
 
     class << self
-      # Is +locale+ constant defined?
+      # Is `locale` constant defined?
       def exists?(locale)
         locale = sanitize_code locale
         name = capitalize(locale)
@@ -81,7 +81,7 @@ module R18n
         "#{lang}#{region}"
       end
 
-      # Load locale by RFC 3066 +code+.
+      # Load locale by RFC 3066 `code`.
       def load(code)
         code = sanitize_code code
         name = capitalize(code)
@@ -96,7 +96,7 @@ module R18n
         end
       end
 
-      # Set locale +properties+. Locale class will have methods
+      # Set locale `properties`. Locale class will have methods
       # for each property name, which return property value:
       #
       #   class R18n::Locales::En < R18n::Locale
@@ -168,13 +168,13 @@ module R18n
       "Locale #{code} (#{title})"
     end
 
-    # Convert +object+ to String. It support Integer, Float, Time, Date
-    # and DateTime.
+    # Convert `object` to `String`. It support `Integer`, `Float`, `Time`,
+    # `Date` and `DateTime`.
     #
-    # For time classes you can set +format+ in standard +strftime+ form,
-    # <tt>:full</tt> (“01 Jule, 2009”), <tt>:human</tt> (“yesterday”),
-    # <tt>:standard</tt> (“07/01/09”) or <tt>:month</tt> for standalone month
-    # name. Default format is <tt>:standard</tt>.
+    # For time classes you can set `format` in standard `strftime` form,
+    # `:full` ("01 Jule, 2009"), `:human` ("yesterday"),
+    # `:standard` ("07/01/09") or `:month` for standalone month
+    # name. Default format is `:standard`.
     def localize(obj, format = nil, *params)
       case obj
       when Integer
@@ -205,8 +205,8 @@ module R18n
       end
     end
 
-    # Returns the integer in String form, according to the rules of the locale.
-    # It will also put real typographic minus.
+    # Returns the integer in `String` form, according to the rules
+    # of the locale. It will also put real typographic minus.
     def format_integer(integer)
       str = integer.to_s
       str[0] = '−' if integer.negative? # Real typographic minus
@@ -217,16 +217,16 @@ module R18n
       end
     end
 
-    # Returns the float in String form, according to the rules of the locale.
+    # Returns the float in `String` form, according to the rules of the locale.
     # It will also put real typographic minus.
     def format_float(float)
       decimal = number_decimal
       format_integer(float.to_i) + decimal + float.to_s.split('.').last
     end
 
-    # Same that <tt>Time.strftime</tt>, but translate months and week days
-    # names. In +time+ you can use Time, DateTime or Date object. In +format+
-    # you can use standard +strftime+ format.
+    # Same that `Time.strftime`, but translate months and week days
+    # names. In `time` you can use `Time`, `DateTime` or `Date` object.
+    # In `format` you can use standard `strftime` format.
     def strftime(time, format)
       translated = ''
       format.scan(/%[EO]?.|./o) do |c|
@@ -249,16 +249,16 @@ module R18n
       time.strftime(translated)
     end
 
-    # Format +time+ and set +date+
+    # Format `time` and set `date`
     def format_time(date, time, with_seconds: false)
       strftime(
         time, with_seconds ? time_with_seconds_format : time_format
       ).sub('_', date.to_s)
     end
 
-    # Format +time+ in human usable form. For example “5 minutes ago” or
-    # “yesterday”. In +now+ you can set base time, which be used to get relative
-    # time. For special cases you can replace it in locale’s class.
+    # Format `time` in human usable form. For example "5 minutes ago" or
+    # "yesterday". In `now` you can set base time, which be used to get relative
+    # time. For special cases you can replace it in locale's class.
     def format_time_human(time, i18n, now = time.class.now, *_params)
       diff = time - now
       minutes = time.is_a?(DateTime) ? diff * 24 * 60.0 : diff / 60.0
@@ -278,22 +278,22 @@ module R18n
       end
     end
 
-    # Format +time+ in compact form. For example, “12/31/09 12:59”.
+    # Format `time` in compact form. For example, "12/31/09 12:59".
     def format_time_standard(time, *params)
       options = params.last.is_a?(Hash) ? params.last : {}
       format_time(format_date_standard(time), time, **options)
     end
 
-    # Format +time+ in most official form. For example, “December 31st, 2009
-    # 12:59”. For special cases you can replace it in locale’s class.
+    # Format `time` in most official form. For example, "December 31st, 2009
+    # 12:59". For special cases you can replace it in locale's class.
     def format_time_full(time, *params)
       options = params.last.is_a?(Hash) ? params.last : {}
       format_time(format_date_full(time), time, **options)
     end
 
-    # Format +date+ in human usable form. For example “5 days ago” or
-    # “yesterday”. In +now+ you can set base time, which be used to get relative
-    # time. For special cases you can replace it in locale’s class.
+    # Format `date` in human usable form. For example "5 days ago" or
+    # "yesterday". In `now` you can set base time, which be used to get relative
+    # time. For special cases you can replace it in locale's class.
     def format_date_human(date, i18n, now = Date.today, *_params)
       days = (date - now).to_i
       case days
@@ -312,13 +312,13 @@ module R18n
       end
     end
 
-    # Format +date+ in compact form. For example, “12/31/09”.
+    # Format `date` in compact form. For example, "12/31/09".
     def format_date_standard(date, *_params)
       strftime(date, date_format)
     end
 
-    # Format +date+ in most official form. For example, “December 31st, 2009”.
-    # For special cases you can replace it in locale’s class. If +year+ is false
+    # Format `date` in most official form. For example, "December 31st, 2009".
+    # For special cases you can replace it in locale's class. If `year` is false
     # date will be without year.
     def format_date_full(date, year = true, *_params)
       format = full_format
@@ -326,8 +326,8 @@ module R18n
       strftime(date, format)
     end
 
-    # Return pluralization type for +number+ of items. This is simple form.
-    # For special cases you can replace it in locale’s class.
+    # Return pluralization type for `number` of items. This is simple form.
+    # For special cases you can replace it in locale's class.
     def pluralize(number)
       case number
       when 0

--- a/r18n-core/lib/r18n-core/translated.rb
+++ b/r18n-core/lib/r18n-core/translated.rb
@@ -22,9 +22,9 @@ module R18n
   # R18n plugin with out-of-box i18n support.
   #
   # Module can add proxy-methods to find translation in object methods. For
-  # example, if you class have +title_en+ and +title_ru+ methods, you can add
-  # proxy-method +title+, which will use +title_ru+ for Russian users and
-  # +title_en+ for English:
+  # example, if you class have `title_en` and `title_ru` methods, you can add
+  # proxy-method `title`, which will use `title_ru` for Russian users and
+  # `title_en` for English:
   #
   #   class Product
   #     include DataMapper::Resource
@@ -58,21 +58,21 @@ module R18n
   # Proxy-method support all funtion from I18n: global and type filters,
   # pluralization, variables. It also return TranslatedString or Untranslated.
   #
-  # By default it use <tt>R18n.get</tt> to get I18n object (so, you must set it
-  # before use model), but you can overwrite object +r18n+ method to change
+  # By default it use `R18n.get` to get I18n object (so, you must set it
+  # before use model), but you can overwrite object `r18n` method to change
   # default logic.
   #
   # See R18n::Translated::Base for class method documentation.
   #
   # == Options
   # You can set option for proxy-method as Hash with keys;
-  # * +type+ – YAML type for filters. For example, "markdown" or "escape_html".
-  # * +methods+ – manual method map as Hash of locale codes to method names.
-  # * +no_params+ – set it to true if you proxy-method must send it parameters
+  # * `type` – YAML type for filters. For example, "markdown" or "escape_html".
+  # * `methods` – manual method map as Hash of locale codes to method names.
+  # * `no_params` – set it to true if you proxy-method must send it parameters
   #   only to filters.
-  # * +no_write+ – set it to true if you don’t want to create proxy-setters.
+  # * `no_write` – set it to true if you don't want to create proxy-setters.
   #
-  # Method +translation+ will be more useful for options:
+  # Method `translation` will be more useful for options:
   #
   #   translation :title, methods: { ru: :russian, en: :english}
   module Translated
@@ -86,18 +86,18 @@ module R18n
     end
 
     # Access to I18n object. By default return global I18n object from
-    # <tt>R18n.get</tt>.
+    # `R18n.get`.
     def r18n
       R18n.get
     end
 
     # Module with class methods, which be added after R18n::Translated include.
     module Base
-      # Hash of translation method names to it type for filters.
+      # `Hash` of translation method names to it type for filters.
       attr_reader :translation_types
 
-      # Add several proxy +methods+. See R18n::Translated for description.
-      # It’s more compact, that +translation+.
+      # Add several proxy `methods`. See R18n::Translated for description.
+      # It's more compact, that `translation`.
       #
       #   translations :title, :keywords, [:desciption, { type: 'markdown' }]
       def translations(*methods)
@@ -106,8 +106,8 @@ module R18n
         end
       end
 
-      # Add proxy-method +name+. See R18n::Translated for description.
-      # It’s more useful to set options.
+      # Add proxy-method `name`. See R18n::Translated for description.
+      # It's more useful to set options.
       #
       #   translation :desciption, type: 'markdown'
       def translation(name, options = {})
@@ -167,14 +167,14 @@ module R18n
         end
       end
 
-      # Return array of methods to find +unlocalized_getters+ or
-      # +unlocalized_setters+.
+      # Return array of methods to find `unlocalized_getters` or
+      # `unlocalized_setters`.
       def unlocalized_methods
         instance_methods
       end
 
-      # Return Hash of locale code to getter method for proxy +method+. If you
-      # didn’t set map in +translation+ option +methods+, it will be detect
+      # Return `Hash` of locale code to getter method for proxy `method`. If you
+      # didn't set map in `translation` option `methods`, it will be detect
       # automatically.
       def unlocalized_getters(method)
         matcher = Regexp.new('^' + Regexp.escape(method.to_s) + '_(\w+)$')
@@ -187,8 +187,8 @@ module R18n
         @unlocalized_getters[method]
       end
 
-      # Return Hash of locale code to setter method for proxy +method+. If you
-      # didn’t set map in +translation+ option +methods+, it will be detect
+      # Return `Hash` of locale code to setter method for proxy `method`. If you
+      # didn't set map in `translation` option `methods`, it will be detect
       # automatically.
       def unlocalized_setters(method)
         matcher = Regexp.new('^' + Regexp.escape(method.to_s) + '_(\w+)=$')

--- a/r18n-core/lib/r18n-core/translated_string.rb
+++ b/r18n-core/lib/r18n-core/translated_string.rb
@@ -28,8 +28,8 @@ module R18n
     # Path for this translation.
     attr_reader :path
 
-    # Returns a new string object containing a copy of +str+, which translated
-    # for +path+ to +locale+
+    # Returns a new string object containing a copy of `str`, which translated
+    # for `path` to `locale`
     def initialize(value, locale, path, filters = nil)
       super(value.to_s)
       @filters = filters

--- a/r18n-core/lib/r18n-core/translation.rb
+++ b/r18n-core/lib/r18n-core/translation.rb
@@ -23,16 +23,16 @@ module R18n
 
   # Translation is container of translated messages.
   #
-  # You can load several locales and if translation willn’t be found in first,
+  # You can load several locales and if translation willn't be found in first,
   # r18n will be search it in next. Use R18n::I18n.new to load translations.
   #
   # To get translation value use method with same name. If translation name
-  # is equal with Object methods (+new+, +to_s+, +methods+) use
-  # <tt>[name, params…]</tt>. If you want to get pluralizable value, just set
+  # is equal with Object methods (`new`, `to_s`, `methods`) use
+  # `[name, params…]`. If you want to get pluralizable value, just set
   # value for pluralization in first argument of method. See samples below.
   #
-  # Translated strings will have +locale+ methods, which return Locale or
-  # UnsupportedLocale, if locale file isn’t exists.
+  # Translated strings will have `locale` methods, which return Locale or
+  # UnsupportedLocale, if locale file isn't exists.
   #
   # == Examples
   # translations/ru.yml
@@ -68,7 +68,7 @@ module R18n
   #   i18n.comments(10)           #=> "10 comments"
   class Translation
     # This is internal a constructor. To load translation use
-    # <tt>R18n::I18n.new(locales, translations_dir)</tt>.
+    # `R18n::I18n.new(locales, translations_dir)`.
     def initialize(locale, path = '', options = {})
       @data    = {}
       @locale  = locale
@@ -78,8 +78,8 @@ module R18n
       merge! options[:translations], options[:locale] if options[:translations]
     end
 
-    # Add another hash with +translations+ for some +locale+. Current data is
-    # more priority, that new one in +translations+.
+    # Add another hash with `translations` for some `locale`. Current data is
+    # more priority, that new one in `translations`.
     def merge!(translations, locale)
       (translations || {}).each_pair do |name, value|
         if !@data.key?(name)
@@ -123,7 +123,7 @@ module R18n
 
     # Return current translation keys.
     #
-    # Deprecated. Use <tt>to_hash.keys</tt>.
+    # Deprecated. Use `to_hash.keys`.
     def translation_keys
       to_hash.keys
     end
@@ -136,15 +136,15 @@ module R18n
       end
     end
 
-    # Return +default+.
+    # Return `default`.
     def |(other)
       other
     end
 
-    # Return translation with special +name+.
+    # Return translation with special `name`.
     #
-    # Translation can contain variable part. Just set is as <tt>%1</tt>,
-    # <tt>%2</tt>, etc in translations file and set values in next +params+.
+    # Translation can contain variable part. Just set is as `%1`,
+    # `%2`, etc in translations file and set values in next `params`.
     def [](name, *params)
       unless [String, Integer, TrueClass, FalseClass]
           .any? { |klass| name.is_a?(klass) }
@@ -166,7 +166,7 @@ module R18n
     end
     alias method_missing []
 
-    # Return translation located at +names+.
+    # Return translation located at `keys`.
     # @see Hash#dig
     def dig(*keys)
       keys.reduce(self) { |result, key| result[key] }

--- a/r18n-core/lib/r18n-core/unsupported_locale.rb
+++ b/r18n-core/lib/r18n-core/unsupported_locale.rb
@@ -26,8 +26,8 @@ module R18n
 
     attr_reader :code, :downcased_code
 
-    # Create object for unsupported locale with +code+ and load other locale
-    # data from +base+ locale.
+    # Create object for unsupported locale with `code` and load other locale
+    # data from `base` locale.
     def initialize(code, _base = nil)
       @code = code
       @downcased_code = @code.downcase.tr('-', '_').freeze

--- a/r18n-core/lib/r18n-core/untranslated.rb
+++ b/r18n-core/lib/r18n-core/untranslated.rb
@@ -18,7 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 module R18n
-  # Return if translation isn’t exists. Unlike nil, it didn’t raise error when
+  # Return if translation isn't exists. Unlike nil, it didn't raise error when
   # you try to access for subtranslations.
   #
   # You can set format to print untranslated string by filters. For example:
@@ -37,7 +37,7 @@ module R18n
   #
   #   R18n::Filters.add(R18n::Untranslated, :hide_untranslated) { '' }
   class Untranslated
-    # Path, that isn’t in translation.
+    # Path, that isn't in translation.
     attr_reader :untranslated_path
 
     # Path, that exists in translation.

--- a/r18n-core/lib/r18n-core/utils.rb
+++ b/r18n-core/lib/r18n-core/utils.rb
@@ -31,8 +31,8 @@ module R18n
       end
     end
 
-    # Invokes +block+ once for each key and value of +hash+. Creates a new hash
-    # with the keys and values returned by the +block+.
+    # Invokes `block` once for each key and value of `hash`. Creates a new hash
+    # with the keys and values returned by the `block`.
     def self.hash_map(hash, &block)
       result = {}
       hash.each_pair do |key, val|

--- a/r18n-core/lib/r18n-core/yaml_loader.rb
+++ b/r18n-core/lib/r18n-core/yaml_loader.rb
@@ -20,13 +20,13 @@
 module R18n
   module Loader
     # Loader for translations in YAML format. Them should have name like
-    # +en.yml+ (English) or en-US.yml (USA English dialect) with
+    # `en.yml` (English) or en-US.yml (USA English dialect) with
     # language/country code (RFC 3066).
     #
     #   R18n::I18n.new('en', R18n::Loader::YAML.new('dir/with/translations'))
     #
     # YAML loader is default loader, so you can just set constructor parameter
-    # to <tt>R18n::I18n.new</tt>:
+    # to `R18n::I18n.new`:
     #
     #   R18n::I18n.new('en', 'dir/with/translations')
     class YAML
@@ -37,20 +37,20 @@ module R18n
       # Dir with translations.
       attr_reader :dir
 
-      # Create new loader for +dir+ with YAML translations.
+      # Create new loader for `dir` with YAML translations.
       def initialize(dir)
         @dir = File.expand_path(dir)
         detect_yaml_private_type
       end
 
-      # Array of locales, which has translations in +dir+.
+      # `Array` of locales, which has translations in `dir`.
       def available
         Dir.glob(File.join(@dir, "**/*.#{FILE_EXT}"))
           .map { |i| File.basename(i, '.*').downcase }.uniq
           .map { |i| R18n.locale(i) }
       end
 
-      # Return Hash with translations for +locale+.
+      # Return `Hash` with translations for `locale`.
       def load(locale)
         initialize_types
 
@@ -63,12 +63,12 @@ module R18n
         transform(translations)
       end
 
-      # YAML loader with same +dir+ will be have same +hash+.
+      # YAML loader with same `dir` will be have same `hash`.
       def hash
         self.class.hash + @dir.hash
       end
 
-      # Is another +loader+ load YAML translations from same +dir+.
+      # Is another `loader` load YAML translations from same `dir`.
       def ==(other)
         self.class == other.class && dir == other.dir
       end

--- a/r18n-core/lib/r18n-core/yaml_methods.rb
+++ b/r18n-core/lib/r18n-core/yaml_methods.rb
@@ -35,7 +35,7 @@ module R18n
       Filters.by_type.each_key do |type|
         next unless type.is_a? String
 
-        # Yeah, I add R18n’s types to global, send me patch if you really
+        # Yeah, I add R18n's types to global, send me patch if you really
         # use YAML types too ;).
         Psych.add_domain_type('yaml.org,2002', type) do |_full_type, value|
           Typed.new(type, value)

--- a/r18n-core/r18n-core.gemspec
+++ b/r18n-core/r18n-core.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |s|
 
   s.author   = 'Andrey Sitnik'
   s.email    = 'andrey@sitnik.ru'
-  s.homepage = 'https://github.com/ai/r18n'
+  s.homepage = 'https://github.com/r18n/r18n'
   s.license  = 'LGPL-3.0'
 end

--- a/r18n-desktop/README.md
+++ b/r18n-desktop/README.md
@@ -14,7 +14,7 @@ information.
 * Flexible locales.
 * Total flexibility.
 
-See full features in [main README](https://github.com/ai/r18n/blob/master/README.md).
+See full features in [main README](https://github.com/r18n/r18n/blob/master/README.md).
 
 ## How To
 

--- a/r18n-desktop/lib/r18n-desktop.rb
+++ b/r18n-desktop/lib/r18n-desktop.rb
@@ -32,8 +32,8 @@ end
 module R18n
   class << self
     # Get user locale from system environment and load I18n object with locale
-    # information and translations from +translations_places+. If user set
-    # locale +manual+ put it as last argument.
+    # information and translations from `translations_places`. If user set
+    # locale `manual` put it as last argument.
     def from_env(translations_places = nil, manual = nil)
       ::R18n.default_places { translations_places }
       locales = Array(R18n::I18n.system_locale)

--- a/r18n-desktop/r18n-desktop.gemspec
+++ b/r18n-desktop/r18n-desktop.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.author   = 'Andrey Sitnik'
   s.email    = 'andrey@sitnik.ru'
-  s.homepage = 'https://github.com/ai/r18n/tree/master/r18n-desktop'
+  s.homepage = 'https://github.com/r18n/r18n/tree/master/r18n-desktop'
   s.license  = 'LGPL-3.0'
 
   s.add_dependency 'r18n-core', "= #{R18n::VERSION}"

--- a/r18n-rails-api/lib/r18n-rails-api/backend.rb
+++ b/r18n-rails-api/lib/r18n-rails-api/backend.rb
@@ -31,9 +31,9 @@ module R18n
 
     RESERVED_KEYS = %i[scope default separator].freeze
 
-    # Find translation in R18n. It didn’t use +locale+ argument, only current
-    # R18n I18n object. Also it doesn’t support Proc and variables in +default+
-    # String option.
+    # Find translation in R18n. It didn't use `locale` argument, only current
+    # R18n I18n object. Also it doesn't support `Proc` and variables in
+    # `default` String option.
     def translate(locale, key, options = {})
       return key.map { |k| translate(locale, k, options) } if key.is_a?(Array)
 
@@ -66,13 +66,13 @@ module R18n
       end
     end
 
-    # Convert +object+ to String, according to the rules of the current
-    # R18n locale. It didn’t use +locale+ argument, only current R18n I18n
-    # object. It support Integer, Float, Time, Date and DateTime.
+    # Convert `object` to `String`, according to the rules of the current
+    # R18n locale. It didn't use `locale` argument, only current R18n I18n
+    # object. It support `Integer`, `Float`, `Time`, `Date` and `DateTime`.
     #
-    # Support Rails I18n (+:default+, +:short+, +:long+, +:long_ordinal+,
-    # +:only_day+ and +:only_second+) and R18n (+:full+, +:human+, +:standard+
-    # and +:month+) time formatters.
+    # Support Rails I18n (`:default`, `:short`, `:long`, `:long_ordinal`,
+    # `:only_day` and `:only_second`) and R18n (`:full`, `:human`, `:standard`
+    # and `:month`) time formatters.
     def localize(locale, object, format = :default, _options = {})
       i18n = get_i18n(locale)
       if format.is_a? Symbol
@@ -127,7 +127,7 @@ module R18n
       end
     end
 
-    # Find translation by <tt>scope.key(params)</tt> in current R18n I18n
+    # Find translation by `scope.key(params)` in current R18n I18n
     # object.
     def lookup(locale, scope, key, separator, params)
       keys = (Array(scope) + Array(key))

--- a/r18n-rails-api/lib/r18n-rails-api/filters.rb
+++ b/r18n-rails-api/lib/r18n-rails-api/filters.rb
@@ -51,7 +51,7 @@ module R18n
   end
 end
 
-# Pluralization by named variable <tt>%{count}</tt>.
+# Pluralization by named variable `%{count}`.
 R18n::Filters.add('pl', :named_pluralization) do |content, config, param|
   if param.is_a?(Hash) && param.key?(:count)
     hash = content.to_hash

--- a/r18n-rails-api/lib/r18n-rails-api/loader.rb
+++ b/r18n-rails-api/lib/r18n-rails-api/loader.rb
@@ -34,27 +34,27 @@ module R18n
     class Rails
       include ::R18n::YamlMethods
 
-      # Create new loader for some +backend+ from Rails I18n. Backend must have
-      # +reload!+, +init_translations+ and +translations+ methods.
+      # Create new loader for some `backend` from Rails I18n. Backend must have
+      # `reload!`, `init_translations` and `translations` methods.
       def initialize(backend = ::I18n::Backend::Simple.new)
         @backend = backend
         detect_yaml_private_type
       end
 
-      # Array of locales, which has translations in +I18n.load_path+.
+      # `Array` of locales, which has translations in `I18n.load_path`.
       def available
         reload!
         @translations.keys.map { |code| R18n.locale(code) }
       end
 
-      # Return Hash with translations for +locale+.
+      # Return `Hash` with translations for `locale`.
       def load(locale)
         initialize_types
         reload!
         @translations[locale.code]
       end
 
-      # Reload backend if <tt>I18n.load_path</tt> is changed.
+      # Reload backend if `I18n.load_path` is changed.
       def reload!
         return if defined?(@last_path) && @last_path == ::I18n.load_path
 
@@ -67,12 +67,12 @@ module R18n
           end
       end
 
-      # Return hash for object and <tt>I18n.load_path</tt>.
+      # Return hash for object and `I18n.load_path`.
       def hash
         ::I18n.load_path.hash
       end
 
-      # Is another +loader+ is also load Rails translations.
+      # Is another `loader` is also load Rails translations.
       def ==(other)
         self.class == other.class
       end

--- a/r18n-rails-api/lib/r18n-rails-api/rails_plural.rb
+++ b/r18n-rails-api/lib/r18n-rails-api/rails_plural.rb
@@ -20,7 +20,7 @@
 module R18n
   # Converter between R18n and Rails I18n plural keys.
   class RailsPlural
-    # Check, that +key+ is Rails plural key.
+    # Check, that `key` is Rails plural key.
     def self.rails?(key)
       %i[zero one few many other].include? key
     end

--- a/r18n-rails-api/r18n-rails-api.gemspec
+++ b/r18n-rails-api/r18n-rails-api.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.author   = 'Andrey Sitnik'
   s.email    = 'andrey@sitnik.ru'
-  s.homepage = 'https://github.com/ai/r18n/tree/master/r18n-rails-api'
+  s.homepage = 'https://github.com/r18n/r18n/tree/master/r18n-rails-api'
   s.license  = 'LGPL-3.0'
 
   s.add_dependency 'i18n', '~> 1'

--- a/r18n-rails/README.md
+++ b/r18n-rails/README.md
@@ -16,7 +16,7 @@ R18n for Rails is fully compatibile with Rails I18n, and add extra features:
 * Flexible locales.
 * Total flexibility.
 
-See full features in [main README](https://github.com/ai/r18n/blob/master/README.md).
+See full features in [main README](https://github.com/r18n/r18n/blob/master/README.md).
 
 ## How To
 
@@ -46,7 +46,7 @@ See full features in [main README](https://github.com/ai/r18n/blob/master/README
      ```
 
 4. Translations in I18n format are stored in
-   <tt>config/locales/<i>locale</i>.yml</tt>:
+   `config/locales/%{locale}.yml`:
 
      ```yaml
     en:
@@ -57,7 +57,7 @@ See full features in [main README](https://github.com/ai/r18n/blob/master/README
           one:  "One user"
           many: "%{count} users"
      ```
-   Translations in R18n format go to <tt>app/i18n/<i>locale</i>.yml</tt>:
+   Translations in R18n format go to `app/i18n/%{locale}.yml`:
 
      ```yaml
     user:
@@ -82,7 +82,7 @@ See full features in [main README](https://github.com/ai/r18n/blob/master/README
     t.user.count(5)
      ```
 
-6. Print dates and numbers in user’s tradition:
+6. Print dates and numbers in user's tradition:
 
      ```ruby
     l Date.today, :standard #=> "2009-12-20"
@@ -94,7 +94,7 @@ See full features in [main README](https://github.com/ai/r18n/blob/master/README
    not only for ActiveRecord models
 
    1. Add to migration columns for each of the supported locales, named as
-      <tt><i>name</i>_<i>locale</i></tt>:
+      `%{name}_%{locale}`:
 
          ```ruby
         t.string :title_en

--- a/r18n-rails/lib/r18n-rails/helpers.rb
+++ b/r18n-rails/lib/r18n-rails/helpers.rb
@@ -21,17 +21,17 @@ module R18n
   module Rails
     module Helpers
       # Return current R18n I18n object, to use R18n API:
-      # * <tt>r18n.available_locales</tt> – available application translations.
-      # * <tt>r18n.locales</tt> – List of user locales
-      # * <tt>r18n.reload!</tt> – Reload R18n translations
+      # * `r18n.available_locales` – available application translations.
+      # * `r18n.locales` – List of user locales
+      # * `r18n.reload!` – Reload R18n translations
       #
-      # You can get translations by <tt>r18n.user.name</tt>, but +t+ helper is
+      # You can get translations by `r18n.user.name`, but `t` helper is
       # more beautiful, short and also support R18n syntax.
       def r18n
         R18n.get
       end
 
-      # Extend +t+ helper to use also R18n syntax.
+      # Extend `t` helper to use also R18n syntax.
       #
       #   t 'user.name' # Rails I18n style
       #   t.user.name   # R18n style
@@ -44,7 +44,7 @@ module R18n
       end
       alias translate t
 
-      # Extend +l+ helper to use also R18n syntax.
+      # Extend `l` helper to use also R18n syntax.
       #
       #   l Time.now                 # Rails I18n default format
       #   l Time.now, format: :short # Rails I18n style

--- a/r18n-rails/r18n-rails.gemspec
+++ b/r18n-rails/r18n-rails.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.author   = 'Andrey Sitnik'
   s.email    = 'andrey@sitnik.ru'
-  s.homepage = 'https://github.com/ai/r18n/tree/master/r18n-rails'
+  s.homepage = 'https://github.com/r18n/r18n/tree/master/r18n-rails'
   s.license  = 'LGPL-3.0'
 
   s.add_dependency 'r18n-rails-api', "= #{R18n::VERSION}"

--- a/r18n-rails/spec/app/config/initializers/r18n.rb
+++ b/r18n-rails/spec/app/config/initializers/r18n.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-# Fix R18n Rails require, because it doesn’t require in global Gemfile.
+# Fix R18n Rails require, because it doesn't require in global Gemfile.
 require 'r18n-rails'

--- a/sinatra-r18n/sinatra-r18n.gemspec
+++ b/sinatra-r18n/sinatra-r18n.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.author   = 'Andrey Sitnik'
   s.email    = 'andrey@sitnik.ru'
-  s.homepage = 'https://github.com/ai/r18n/tree/master/sinatra-r18n'
+  s.homepage = 'https://github.com/r18n/r18n/tree/master/sinatra-r18n'
   s.license  = 'LGPL-3.0'
 
   s.add_dependency 'r18n-core', "= #{R18n::VERSION}"


### PR DESCRIPTION
Replace `’`, `“` and `”` with more standard `'` and `"`, except licenses.

Replace `+` and `<tt>` with `` ` ``, `<i></i>` with `%{}`.

Wrap some code (classes) into `` ` ``.

Update GitHub links from `ai/r18n` to `r18n/r18n`.

Update documentation about locale adding.

Add anchor-links to mentioned README sections.