### PR TITLE
Set `I18n#locale` with region by its parent equal to received locale

### DIFF
--- a/r18n-core/lib/r18n-core/i18n.rb
+++ b/r18n-core/lib/r18n-core/i18n.rb
@@ -208,8 +208,12 @@ module R18n
       unless defined? @locale
         available_in_places.each do |_place, available|
           @locales.each do |locale|
-            if available.include? locale
-              @locale = locale
+            found_available =
+              (locale if available.include?(locale)) ||
+              available.find { |available_one| available_one.parent == locale }
+
+            if found_available
+              @locale = found_available
               break
             end
           end

--- a/r18n-core/spec/i18n_spec.rb
+++ b/r18n-core/spec/i18n_spec.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 describe R18n::I18n do
+  module R18n
+    module Locales
+      class RuRU < Ru
+        set sublocales: %w[ru]
+      end
+    end
+  end
+
   before do
     @extension_places = R18n.extension_places.clone
   end
@@ -233,6 +241,15 @@ describe R18n::I18n do
     i18n = R18n::I18n.new(%w[notransl nolocale ru en], DIR)
     expect(i18n.locale).to      eq(R18n.locale('nolocale'))
     expect(i18n.locale.base).to eq(R18n.locale('ru'))
+  end
+
+  describe 'locales with regions when getting locales without' do
+    it 'returns locale with region by found parent' do
+      i18n = R18n::I18n.new(
+        %w[notransl ru en], File.join(TRANSLATIONS, 'with_regions')
+      )
+      expect(i18n.locale).to eq(R18n.locale('ru-RU'))
+    end
   end
 
   it 'localizes objects' do

--- a/r18n-core/spec/yaml_loader_spec.rb
+++ b/r18n-core/spec/yaml_loader_spec.rb
@@ -46,6 +46,7 @@ describe R18n::Loader::YAML do
     loader = R18n::Loader::YAML.new(TRANSLATIONS)
     expect(loader.available).to match_array([
       R18n.locale('ru'),
+      R18n.locale('ru-ru'),
       R18n.locale('en'),
       R18n.locale('en-us'),
       R18n.locale('en-gb'),


### PR DESCRIPTION
For example, if project has `en-US` and `de-DE` locales, and `Accept-Language` header contains only `de` — set `de-DE` as locale.