### PR TITLE
Allow Hashes with blocks for `named_variables` filter

### DIFF
--- a/r18n-core/lib/r18n-core/filters.rb
+++ b/r18n-core/lib/r18n-core/filters.rb
@@ -260,13 +260,13 @@ module R18n
   Filters.add(String, :named_variables) do |content, config, params|
     if params.is_a? Hash
       content = content.clone
-      params.each_pair do |name, value|
-        value = config[:locale].localize(value)
+      content.gsub!(/(?:%{(\w+)}|{{(\w+)}})/) do |name|
+        key = name.delete('%{}').to_sym
+        value = config[:locale].localize(params[key])
         if defined? ActiveSupport::SafeBuffer
           value = ActiveSupport::SafeBuffer.new + value
         end
-        content.gsub! "%{#{name}}",  value
-        content.gsub! "{{#{name}}}", value
+        value
       end
     end
     content

--- a/r18n-core/spec/filters_spec.rb
+++ b/r18n-core/spec/filters_spec.rb
@@ -205,6 +205,11 @@ describe R18n::Filters do
 
     expect(@i18n.echo2(value: 'R18n')).to eq 'Value2 is R18n'
     expect(@i18n.echo2).to eq 'Value2 is {{value}}'
+
+    translate_hash = Hash.new { |hash, key| hash[key] = key.to_s * 2 }
+    expect(@i18n.echo3(translate_hash)).to eq(
+      'Value3 is value3value3 and value4 is value4value4'
+    )
   end
   # rubocop:enable Style/FormatStringToken
 

--- a/r18n-core/spec/translations/general/en.yml
+++ b/r18n-core/spec/translations/general/en.yml
@@ -41,6 +41,7 @@ textile:
 
 echo: Value is %{value}
 echo2: Value2 is {{value}}
+echo3: Value3 is {{value3}} and value4 is {{value4}}
 
 boolean:
   true: Boolean is true


### PR DESCRIPTION
It will force Symbol keys, but it does not break specs
and it's more flexible.