### PR TITLE
Remove block setters

### DIFF
--- a/r18n-core/lib/r18n-core.rb
+++ b/r18n-core/lib/r18n-core.rb
@@ -41,34 +41,18 @@ module R18n
   class << self
     # Set I18n object globally. You can miss translation `places`, it will be
     # taken from `R18n.default_places`.
-    def set(i18n = nil, places = R18n.default_places, &block)
-      @i18n =
-        if block_given?
-          @setter = block
-          nil
-        elsif i18n.is_a? I18n
-          i18n
-        else
-          I18n.new(i18n, places)
-        end
+    def set(i18n, places = R18n.default_places)
+      @i18n = i18n.is_a?(I18n) ? i18n : I18n.new(i18n, places)
     end
 
     # Set I18n object to current thread.
-    def thread_set(i18n = nil, &block)
-      if block_given?
-        thread[:r18n_setter] = block
-        thread[:r18n_i18n]   = nil
-      else
-        thread[:r18n_i18n] = i18n
-      end
+    def thread_set(i18n)
+      thread[:r18n_i18n] = i18n
     end
 
     # Get I18n object for current thread.
     def get
-      thread[:r18n_i18n] ||
-        (thread[:r18n_setter] && thread_set(thread[:r18n_setter].call)) ||
-        @i18n ||
-        (@setter && set(@setter.call))
+      thread[:r18n_i18n] || @i18n
     end
 
     # Clean translations cache.

--- a/r18n-core/spec/r18n_spec.rb
+++ b/r18n-core/spec/r18n_spec.rb
@@ -23,7 +23,7 @@ describe R18n do
     R18n.set(i18n)
 
     i18n = R18n::I18n.new('ru')
-    R18n.set { i18n }
+    R18n.set(i18n)
 
     expect(R18n.get).to eq(i18n)
   end
@@ -40,16 +40,6 @@ describe R18n do
     expect(R18n.get.translation_places).to eq(
       [R18n::Loader::YAML.new(general_translations_dir)]
     )
-  end
-
-  it 'allows to return I18n arguments in setter block' do
-    R18n.set { 'en' }
-    expect(R18n.get.locales).to eq [
-      R18n.locale('en'),
-      R18n.locale('en-US'),
-      R18n.locale('en-GB'),
-      R18n.locale('en-AU')
-    ]
   end
 
   it 'clears cache' do
@@ -74,7 +64,7 @@ describe R18n do
     expect(R18n.get).to eq(i18n)
 
     i18n = R18n::I18n.new('ru')
-    R18n.thread_set { i18n }
+    R18n.thread_set(i18n)
     expect(R18n.get).to eq(i18n)
   end
 


### PR DESCRIPTION
I don't know why (for what) they were here,
they were introduced in d14728cb3ec615d28b90e041000583a93df38dd1
without any description.

I see no profit from such approach.
Use regular `set` or justify the necessity, please.